### PR TITLE
[METAL-2096] Save database name and user info in CR status

### DIFF
--- a/pkg/apis/kci/v1alpha1/database_types.go
+++ b/pkg/apis/kci/v1alpha1/database_types.go
@@ -30,6 +30,8 @@ type DatabaseStatus struct {
 	InstanceRef           *DbInstance         `json:"instanceRef"`
 	MonitorUserSecretName string              `json:"monitorUserSecret,omitempty"`
 	ProxyStatus           DatabaseProxyStatus `json:"proxyStatus,omitempty"`
+	DatabaseName          string              `json:"database"`
+	UserName              string              `json:"user"`
 }
 
 // DatabaseProxyStatus defines whether proxy for database is enabled or not

--- a/pkg/controller/database/controller.go
+++ b/pkg/controller/database/controller.go
@@ -207,12 +207,6 @@ func (r *ReconcileDatabase) Reconcile(request reconcile.Request) (reconcile.Resu
 				// when database creation failed, don't requeue request. to prevent exceeding api limit (ex: against google api)
 				return r.manageError(dbcr, err, false)
 			}
-			kci.AddFinalizer(&dbcr.ObjectMeta, "db."+dbcr.Name)
-			err = r.client.Update(context.Background(), dbcr)
-			if err != nil {
-				logrus.Errorf("error resource updating - %s", err)
-				return r.manageError(dbcr, err, true)
-			}
 			dbcr.Status.Phase = phaseInstanceAccessSecret
 		case phaseInstanceAccessSecret:
 			err := r.createInstanceAccessSecret(dbcr)


### PR DESCRIPTION
remove re-generating database name and user part to execute deletion of the database.
instead, database name and user name are saved in cr itself