### PR TITLE
METAL-2104 change hash call, to get only hash value for func return

### DIFF
--- a/pkg/utils/kci/database.go
+++ b/pkg/utils/kci/database.go
@@ -27,5 +27,6 @@ func StringSanitize(s string, limit int) string {
 		return fmt.Sprintf("%x", sha256.New().Sum([]byte(s)))[:limit]
 	}
 
-	return fmt.Sprintf("%s_%x", s[:limit-9], sha256.New().Sum([]byte(s))[:4])
+	hash := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%s_%x", s[:limit-9], hash[:4])
 }

--- a/pkg/utils/kci/database.go
+++ b/pkg/utils/kci/database.go
@@ -23,10 +23,11 @@ func StringSanitize(s string, limit int) string {
 		return s
 	}
 
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(s)))
+
 	if limit <= 9 {
-		return fmt.Sprintf("%x", sha256.New().Sum([]byte(s)))[:limit]
+		return hash[:limit]
 	}
 
-	hash := sha256.Sum256([]byte(s))
-	return fmt.Sprintf("%s_%x", s[:limit-9], hash[:4])
+	return fmt.Sprintf("%s_%s", s[:limit-9], hash[:8])
 }

--- a/pkg/utils/kci/database_test.go
+++ b/pkg/utils/kci/database_test.go
@@ -9,7 +9,7 @@ func TestStringSanitize(t *testing.T) {
 	// Handles very short limits
 	src := "HelloWorld"
 	actual := StringSanitize(src, 6)
-	assert.Equal(t, "68656c", actual)
+	assert.Equal(t, "936a18", actual)
 
 	// Sanitizes successfully
 	src = "Hello**World$"

--- a/pkg/utils/kci/database_test.go
+++ b/pkg/utils/kci/database_test.go
@@ -19,5 +19,10 @@ func TestStringSanitize(t *testing.T) {
 	// Truncates very long values
 	src = "The quick brown fox jumps over the lazy dog"
 	actual = StringSanitize(src, 32)
-	assert.Equal(t, "the_quick_brown_fox_jum_7468655f", actual)
+	assert.Equal(t, "the_quick_brown_fox_jum_19e1ae50", actual)
+
+	// Truncates very long values, avoid hash collision
+	src = "The quick brown fox jumps over the lazy cat"
+	actual = StringSanitize(src, 32)
+	assert.NotEqual(t, "the_quick_brown_fox_jum_19e1ae50", actual)
 }


### PR DESCRIPTION
With adding more verbose db names for mysql, the name generation can result in a collision.

This is a small fix for this, adding unit test to avoid this in future.