### PR TITLE
METAL-2665 add Prometheus PushGateway as optional config parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ minidashboard:
 	@minikube dashboard
 
 build:
-	@eval $$(minikube docker-env) ;\
+	@eval $$(shell minikube docker-env) ;\
 	operator-sdk build my-db-operator:local
 
 helm:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ minidashboard:
 	@minikube dashboard
 
 build:
-	@eval $$(shell minikube docker-env) ;\
+	@eval $$(minikube docker-env) ;\
 	operator-sdk build my-db-operator:local
 
 helm:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,8 @@ backup:
     image: kloeckneri/pgdump-gcs:latest
   mysql: {}
 monitoring:
+  # append as an ENV variable "PROMETHEUS_PUSH_GATEWAY" to the backup cronjob
+  promPushGateway: ""
   nodeSelector: {}
   postgres:
     image: wrouesnel/postgres_exporter:latest

--- a/docs/enablingbackup.md
+++ b/docs/enablingbackup.md
@@ -89,4 +89,4 @@ The Cronjob needs permission to push the dump file to the GCS bucket. It will us
 
 ## Monitoring
 
-For monitoring a backup job, you can define in the db-operator config a general prometheus pushgateway endpoint (`monitoring.promPushGateway`). If monitoring is enabled, this variable is added to the related backup cronjob enviorment variables as `PROMETHEUS_PUSH_GATEWAY`.
+For monitoring a backup job, you can define in the db-operator config a general prometheus pushgateway endpoint (`monitoring.promPushGateway`). If monitoring is enabled, this variable is added to the related backup cronjob environment variables as `PROMETHEUS_PUSH_GATEWAY`.

--- a/docs/enablingbackup.md
+++ b/docs/enablingbackup.md
@@ -86,3 +86,7 @@ spec:
 The DB Operator will create a kubernetes Cronjob in the same namespace of Database to run backup regularly.
 
 The Cronjob needs permission to push the dump file to the GCS bucket. It will use Secret `google-cloud-storage-bucket-cred`.
+
+## Monitoring
+
+For monitoring a backup job, you can define in the db-operator config a general prometheus pushgateway endpoint (`monitoring.promPushGateway`). If monitoring is enabled, this variable is added to the related backup cronjob enviorment variables as `PROMETHEUS_PUSH_GATEWAY`.

--- a/examples/db.yaml
+++ b/examples/db.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   secretName: example-db-credentials # where to save db name user, password for application
   instance: example-instance
+  deletionProtected: false
   backup:
     enable: false
     cron: "0 0 * * *"

--- a/examples/instance-generic.yaml
+++ b/examples/instance-generic.yaml
@@ -3,7 +3,7 @@ kind: DbInstance
 metadata:
   name: "example-generic"
 spec:
-  adminSecretRef: 
+  adminSecretRef:
     Name: example-instance-admin-secret
     Namespace: << namespace of admin secret >>
   engine: postgres

--- a/helm/db-operator/templates/config.yaml
+++ b/helm/db-operator/templates/config.yaml
@@ -29,8 +29,8 @@ data:
       mysql:
         image: {{ .Values.config.backup.mysql.image }}
     monitoring:
-    {{- if .Values.config.monitoring.promPushGateWay }}
-      promPushGateWay: {{ .Values.config.monitoring.promPushGateWay }}
+    {{- if .Values.config.monitoring.promPushGateway }}
+      promPushGateway: {{ .Values.config.monitoring.promPushGateway }}
     {{ end }}
       nodeSelector:
 {{ toYaml .Values.config.monitoring.nodeSelector | indent 8 }}

--- a/helm/db-operator/templates/config.yaml
+++ b/helm/db-operator/templates/config.yaml
@@ -29,6 +29,9 @@ data:
       mysql:
         image: {{ .Values.config.backup.mysql.image }}
     monitoring:
+    {{- if .Values.config.monitoring.promPushGateWay }}
+      promPushGateWay: {{ .Values.config.monitoring.promPushGateWay }}
+    {{ end }}
       nodeSelector:
 {{ toYaml .Values.config.monitoring.nodeSelector | indent 8 }}
       postgres:

--- a/helm/db-operator/values.yaml
+++ b/helm/db-operator/values.yaml
@@ -44,7 +44,7 @@ config:
     mysql:
       image: "kloeckneri/mydump-gcs:latest"
   monitoring:
-    promPushGateWay: ""
+    promPushGateway: ""
     nodeSelector: {}
     postgres:
       image: wrouesnel/postgres_exporter:latest

--- a/helm/db-operator/values.yaml
+++ b/helm/db-operator/values.yaml
@@ -44,6 +44,7 @@ config:
     mysql:
       image: "kloeckneri/mydump-gcs:latest"
   monitoring:
+    promPushGateWay: ""
     nodeSelector: {}
     postgres:
       image: wrouesnel/postgres_exporter:latest

--- a/pkg/config/test/config_ok.yaml
+++ b/pkg/config/test/config_ok.yaml
@@ -17,6 +17,7 @@ backup:
     image: mysqlbackupimage:latest
 monitoring:
   nodeSelector: {}
+  promPushGateway: foo.bar:9200
   postgres:
     image: wrouesnel/postgres_exporter:latest
     queries: |-

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -51,9 +51,10 @@ type mysqlBackupConfig struct {
 // monitoringConfig defines prometheus exporter configurations
 // which will be created by db-operator when monitoring is enabled
 type monitoringConfig struct {
-	Postgres     postgresMonitoringConfig `yaml:"postgres"`
-	Mysql        mysqlMonitoringConfig    `yaml:"mysql,omitempty"`
-	NodeSelector map[string]string        `yaml:"nodeSelector"`
+	Postgres        postgresMonitoringConfig `yaml:"postgres"`
+	Mysql           mysqlMonitoringConfig    `yaml:"mysql,omitempty"`
+	NodeSelector    map[string]string        `yaml:"nodeSelector"`
+	PromPushGateway string                   `yaml:"promPushGateWay,omitempty"`
 }
 
 type postgresMonitoringConfig struct {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -54,7 +54,7 @@ type monitoringConfig struct {
 	Postgres        postgresMonitoringConfig `yaml:"postgres"`
 	Mysql           mysqlMonitoringConfig    `yaml:"mysql,omitempty"`
 	NodeSelector    map[string]string        `yaml:"nodeSelector"`
-	PromPushGateway string                   `yaml:"promPushGateWay,omitempty"`
+	PromPushGateway string                   `yaml:"promPushGateway,omitempty"`
 }
 
 type postgresMonitoringConfig struct {

--- a/pkg/controller/database/backup/cronjob.go
+++ b/pkg/controller/database/backup/cronjob.go
@@ -178,8 +178,7 @@ func postgresEnvVars(dbcr *kciv1alpha1.Database) ([]v1.EnvVar, error) {
 	}
 
 	port := instance.Status.Info["DB_PORT"]
-
-	return []v1.EnvVar{
+	envList := []v1.EnvVar{
 		v1.EnvVar{
 			Name: "DB_HOST", Value: host,
 		},
@@ -203,7 +202,14 @@ func postgresEnvVars(dbcr *kciv1alpha1.Database) ([]v1.EnvVar, error) {
 		v1.EnvVar{
 			Name: "GCS_BUCKET", Value: instance.Spec.Backup.Bucket,
 		},
-	}, nil
+	}
+
+	if ok, _ := dbcr.IsMonitoringEnabled(); ok {
+		envList = append(envList, v1.EnvVar{
+			Name: "PROMETHEUS_PUSH_GATEWAY", Value: conf.Monitoring.PromPushGateway,
+		})
+	}
+	return envList, nil
 }
 
 func mysqlEnvVars(dbcr *kciv1alpha1.Database) ([]v1.EnvVar, error) {

--- a/pkg/controller/database/backup/cronjob.go
+++ b/pkg/controller/database/backup/cronjob.go
@@ -204,7 +204,7 @@ func postgresEnvVars(dbcr *kciv1alpha1.Database) ([]v1.EnvVar, error) {
 		},
 	}
 
-	if ok, _ := dbcr.IsMonitoringEnabled(); ok {
+	if instance.IsMonitoringEnabled() {
 		envList = append(envList, v1.EnvVar{
 			Name: "PROMETHEUS_PUSH_GATEWAY", Value: conf.Monitoring.PromPushGateway,
 		})


### PR DESCRIPTION
Add functionality to add a prometheus pushgateway env-variable to the cronjob for monitoring backup metrics.