### PR TITLE
[METAL-2726] Use db-auth-gateway by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ instance:
     clientSecretName: "cloudsql-readonly-serviceaccount"
     proxy:
       nodeSelector: {}
-      image: gcr.io/cloudsql-docker/gce-proxy:1.11
+      image: kloeckneri/db-auth-gateway:0.1.7
   generic: {}
 backup:
   nodeSelector: {}

--- a/helm/README.md
+++ b/helm/README.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters of the db-operator chart a
 | `nodeSelector`        | Node labels for pod assignment        | `{}`                      |
 | `affinity`            | Node affinity for pod assignment      | `{}`                      |
 | `annotations`         | Annotations to add to the db-operator pod | `{}`                  |
-| `config.instance.google.proxy.image` | Container image of google cloud proxy | `gcr.io/cloudsql-docker/gce-proxy:1.11` |
+| `config.instance.google.proxy.image` | Container image of db-auth-gateway | `kloeckneri/db-auth-gateway:0.1.7` |
 | `config.instance.google.proxy.nodeSelector` | Node labels for google cloud proxy pod assignment | `{}` |
 | `config.backup.nodeSelector` | Node labels for backup pod assignment | `{}` |
 | `config.backup.activeDeadlineSeconds` | activeDeadlineSeconds of backup cronjob | `600` |

--- a/helm/db-operator/values.yaml
+++ b/helm/db-operator/values.yaml
@@ -30,7 +30,7 @@ config:
     google:
       proxy:
         nodeSelector: {}
-        image: gcr.io/cloudsql-docker/gce-proxy:1.16
+        image: kloeckneri/db-auth-gateway:0.1.7
     generic: {}
     percona:
       proxy:

--- a/pkg/config/test/config_ok.yaml
+++ b/pkg/config/test/config_ok.yaml
@@ -3,7 +3,7 @@ instance:
     clientSecretName: "cloudsql-readonly-serviceaccount"
     proxy:
       nodeSelector: {}
-      image: gcr.io/cloudsql-docker/gce-proxy:1.11
+      image: kloeckneri/db-auth-gateway:0.1.7
   generic: {}
   percona:
     proxy:


### PR DESCRIPTION
Use the db-auth-gateway by default for all proxy deployments.