### PR TITLE
Fix Github Packages requirement and change to v1.0.0

### DIFF
--- a/helm/db-operator/Chart.yaml
+++ b/helm/db-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.13.1"
+appVersion: "1.0.0"
 description: A Database Operator
 name: db-operator
 version: 0.6.3

--- a/helm/db-operator/templates/_helpers.tpl
+++ b/helm/db-operator/templates/_helpers.tpl
@@ -39,6 +39,13 @@ Image version definition;
 {{- end -}}
 
 {{/*
+Image version definition using Github Packages format ('v' prefix);
+*/}}
+{{- define "db-operator.github_packages_image_version" -}}
+{{- printf "v%s" (default .Chart.AppVersion .Values.image.tag) }}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "db-operator.serviceAccountName" -}}

--- a/helm/db-operator/templates/operator.yaml
+++ b/helm/db-operator/templates/operator.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       containers:
         - name: operator
-          image: "{{ .Values.image.repository }}:{{ template "db-operator.image_version" . }}"
+          image: "{{ .Values.image.repository }}:{{ template "db-operator.github_packages_image_version" . }}"
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
It appears that when you moved cloudish-sql to Github Packages, the image tag is a different format. It seems you are missing a 'v' before the version number [in the image tag](https://github.com/kloeckner-i/cloudish-sql/pkgs/container/cloudish-sql). It says it should be

`docker pull ghcr.io/kloeckner-i/cloudish-sql:v1.0.0`

Not sure if that is changeable from Github Packages. It would be nice if they didn't use that 'v'.

Also, you only have v1.0.0 in Github Packages, so the image pull fails when you install the Helm chart since the app version was set to 0.13.1, and (v)0.13.1 isn't available in Github Packages.

Definitely a lot of ways to fix, but I thought I would give you one option. Thanks for this project by the way....it would be nice however if there was an option not to install the Google SQL stuff. :)