### PR TITLE
Update crds and rbac for Kubernetes v1.22+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ vet: $(SRC)
 minisetup: miniup miniimage helm
 
 miniup: ## start minikube
-	@minikube start --kubernetes-version=v1.19.12 --cpus 2 --memory 4096
+	@minikube start --kubernetes-version=v1.22.3 --cpus 2 --memory 4096
 
 minidown: ## stop minikube
 	@minikube stop
@@ -74,7 +74,7 @@ k3d_setup: k3d_install k3d_image helm ## install microk8s locally and deploy db-
 
 k3d_install:
 	@wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
-	@k3d cluster create myk3s -i rancher/k3s:v1.19.12-k3s1
+	@k3d cluster create myk3s -i rancher/k3s:v1.22.3+k3s1
 	@kubectl get pod
 
 k3d_image: build

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ k3d_setup: k3d_install k3d_image helm ## install microk8s locally and deploy db-
 
 k3d_install:
 	@wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
-	@k3d cluster create myk3s -i rancher/k3s:v1.22.3+k3s1
+	@k3d cluster create myk3s -i rancher/k3s:v1.22.3-k3s1
 	@kubectl get pod
 
 k3d_image: build

--- a/helm/db-operator/templates/crd.yaml
+++ b/helm/db-operator/templates/crd.yaml
@@ -1,3 +1,144 @@
+{{- define "dboperator.dbinstanceschema" -}}
+type: object
+properties:
+  apiVersion:
+    description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+    type: string
+  kind:
+    description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+    type: string
+  metadata:
+    type: object
+  spec:
+    description: DbInstanceSpec defines the desired state of DbInstance
+    type: object
+    required:
+      - adminSecretRef
+      - engine
+    oneOf:
+      - required:
+          - percona
+      - required:
+          - google
+      - required:
+          - generic
+    properties:
+      engine:
+        type: string
+      adminSecretRef:
+        type: object
+        properties:
+          Namespace:
+            type: string
+          Name:
+            type: string
+      backup:
+        type: object
+        properties:
+          bucket:
+            type: string
+        required:
+          - bucket
+      generic:
+        properties:
+          backupHost:
+            description: BackupHost address will be used for dumping database for backup Usually secondary address for primary-secondary setup or cluster lb address If it's not defined, above Host will be used as backup host address.
+            type: string
+          host:
+            type: string
+          port:
+            type: integer
+          publicIp:
+            type: string
+        required:
+          - host
+          - port
+        type: object
+      google:
+        description: GoogleInstance is used when instance type is Google Cloud SQL and describes necessary informations to use google API to create sql instances
+        properties:
+          configmapRef:
+            type: object
+          instance:
+            type: string
+        required:
+          - configmapRef
+          - instance
+        type: object
+      percona:
+        description: PerconaCluster is used when instance type is percona cluster
+        properties:
+          servers:
+            type: array
+            items:
+              description: BackendServer defines backend database server
+              required:
+                - host
+                - maxConn
+                - port
+              properties:
+                host:
+                  type: string
+                maxConn:
+                  minimum: 1
+                  type: integer
+                port:
+                  type: integer
+                readonly:
+                  type: boolean
+              type: object
+          monitorUserSecretRef:
+            type: object
+        required:
+          - monitorUserSecretRef
+          - servers
+        type: object
+      monitoring:
+        type: object
+        properties:
+          enabled:
+            type: boolean
+        required:
+          - enabled
+      sslConnection:
+        description: DbInstanceSSLConnection defines weather connection from db-operator to instance has to be ssl or not
+        properties:
+          enabled:
+            type: boolean
+          skip-verify:
+            description: SkipVerity use SSL connection, but don't check against a CA
+            type: boolean
+        required:
+          - enabled
+          - skip-verify
+        type: object
+  status:
+    description: DbInstanceStatus defines the observed state of DbInstance
+    type: object
+    properties:
+      phase:
+        type: string
+      status:
+        type: boolean
+      info:
+        type: object
+        properties:
+          DB_PORT:
+            type: string
+          DB_CONN:
+            type: string
+      checksums:
+        type: object
+        properties:
+          spec:
+            type: string
+          config:
+            type: string
+{{- end -}}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -75,23 +216,12 @@ spec:
                   type: string
                 instanceRef:
                   description: DbInstance is the Schema for the dbinstances API
-                  properties:
-                    apiVersion:
-                      description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                      type: string
-                    kind:
-                      description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
+{{ include "dboperator.dbinstanceschema" . | indent 18 }}
                     metadata:
                       type: object
-                    spec:
-                      description: DbInstanceSpec defines the desired state of DbInstance
-                      type: object
-                    status:
-                      description: DbInstanceStatus defines the observed state of DbInstance
-                      type: object
-                  type: object
-                  additionalProperties: true
+                      properties:
+                        name:
+                          type: string
                 monitorUserSecret:
                   type: string
                 phase:
@@ -175,126 +305,7 @@ spec:
       schema:
         openAPIV3Schema:
           description: DbInstance is the Schema for the dbinstances API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: DbInstanceSpec defines the desired state of DbInstance
-              type: object
-              required:
-                - adminSecretRef
-                - engine
-              oneOf:
-                - required:
-                  - percona
-                - required:
-                  - google
-                - required:
-                  - generic
-              properties:
-                engine:
-                  type: string
-                adminSecretRef:
-                  type: object
-                  properties:
-                    Namespace:
-                      type: string
-                    Name:
-                      type: string
-                backup:
-                  type: object
-                  properties:
-                    bucket:
-                      type: string
-                  required:
-                    - bucket
-                generic:
-                  properties:
-                    backupHost:
-                      description: BackupHost address will be used for dumping database for backup Usually secondary address for primary-secondary setup or cluster lb address If it's not defined, above Host will be used as backup host address.
-                      type: string
-                    host:
-                      type: string
-                    port:
-                      type: integer
-                    publicIp:
-                      type: string
-                  required:
-                    - host
-                    - port
-                  type: object
-                google:
-                  description: GoogleInstance is used when instance type is Google Cloud SQL and describes necessary informations to use google API to create sql instances
-                  properties:
-                    configmapRef:
-                      type: object
-                    instance:
-                      type: string
-                  required:
-                    - configmapRef
-                    - instance
-                  type: object
-                percona:
-                  description: PerconaCluster is used when instance type is percona cluster
-                  properties:
-                    servers:
-                      type: array
-                      items:
-                        description: BackendServer defines backend database server
-                        required:
-                          - host
-                          - maxConn
-                          - port
-                        properties:
-                          host:
-                            type: string
-                          maxConn:
-                            minimum: 1
-                            type: integer
-                          port:
-                            type: integer
-                          readonly:
-                            type: boolean
-                        type: object
-                    monitorUserSecretRef:
-                      type: object
-                  required:
-                    - monitorUserSecretRef
-                    - servers
-                  type: object
-                monitoring:
-                  type: object
-                  properties:
-                    enabled:
-                      type: boolean
-                  required:
-                    - enabled
-                sslConnection:
-                  description: DbInstanceSSLConnection defines weather connection from db-operator to instance has to be ssl or not
-                  properties:
-                    enabled:
-                      type: boolean
-                    skip-verify:
-                      description: SkipVerity use SSL connection, but don't check against a CA
-                      type: boolean
-                  required:
-                    - enabled
-                    - skip-verify
-                  type: object
-            status:
-              description: DbInstanceStatus defines the observed state of DbInstance
-              type: object
-          type: object
+{{ include "dboperator.dbinstanceschema" . | indent 10 }}
       additionalPrinterColumns:
       - jsonPath: .status.phase
         description: current phase

--- a/helm/db-operator/templates/crd.yaml
+++ b/helm/db-operator/templates/crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: databases.kci.rocks
@@ -11,140 +11,143 @@ metadata:
 spec:
   group: kci.rocks
   scope: Namespaced
-  version: v1alpha1
   names:
     kind: Database
     listKind: DatabaseList
     plural: databases
     singular: database
     shortNames:
-    - db
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Database is the Schema for the databases API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: DatabaseSpec defines the desired state of Database
+      - db
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: Database is the Schema for the databases API
           properties:
-            backup:
-              description: DatabaseBackup defines the desired state of backup and schedule
-              properties:
-                cron:
-                  type: string
-                enable:
-                  type: boolean
-              required:
-                - cron
-                - enable
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
-            deletionProtected:
-              type: boolean
-            extensions:
-              items:
-                type: string
-              type: array
-            instance:
-              type: string
-            secretName:
-              description: 'Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-          required:
-            - backup
-            - deletionProtected
-            - instance
-            - secretName
-          type: object
-          additionalProperties: true
-        status:
-          description: DatabaseStatus defines the observed state of Database
-          properties:
-            database:
-              type: string
-            instanceRef:
-              description: DbInstance is the Schema for the dbinstances API
+            spec:
+              description: DatabaseSpec defines the desired state of Database
               properties:
-                apiVersion:
-                  description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                backup:
+                  description: DatabaseBackup defines the desired state of backup and schedule
+                  properties:
+                    cron:
+                      type: string
+                    enable:
+                      type: boolean
+                  required:
+                    - cron
+                    - enable
+                  type: object
+                deletionProtected:
+                  type: boolean
+                extensions:
+                  items:
+                    type: string
+                  type: array
+                instance:
                   type: string
-                kind:
-                  description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                secretName:
+                  description: 'Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
                   type: string
-                metadata:
-                  type: object
-                spec:
-                  description: DbInstanceSpec defines the desired state of DbInstance
-                  type: object
-                status:
-                  description: DbInstanceStatus defines the observed state of DbInstance
-                  type: object
+              required:
+                - backup
+                - deletionProtected
+                - instance
+                - secretName
               type: object
               additionalProperties: true
-            monitorUserSecret:
-              type: string
-            phase:
-              description: 'Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              type: string
-            proxyStatus:
-              description: DatabaseProxyStatus defines whether proxy for database is enabled or not if so, provide information
+            status:
+              description: DatabaseStatus defines the observed state of Database
               properties:
-                serviceName:
+                database:
                   type: string
-                sqlPort:
-                  format: int32
-                  type: integer
+                instanceRef:
+                  description: DbInstance is the Schema for the dbinstances API
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      type: object
+                    spec:
+                      description: DbInstanceSpec defines the desired state of DbInstance
+                      type: object
+                    status:
+                      description: DbInstanceStatus defines the observed state of DbInstance
+                      type: object
+                  type: object
+                  additionalProperties: true
+                monitorUserSecret:
+                  type: string
+                phase:
+                  description: 'Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                  type: string
+                proxyStatus:
+                  description: DatabaseProxyStatus defines whether proxy for database is enabled or not if so, provide information
+                  properties:
+                    serviceName:
+                      type: string
+                    sqlPort:
+                      format: int32
+                      type: integer
+                    status:
+                      type: boolean
+                  required:
+                    - serviceName
+                    - sqlPort
+                    - status
+                  type: object
                 status:
                   type: boolean
+                user:
+                  type: string
               required:
-                - serviceName
-                - sqlPort
+                - database
+                - instanceRef
+                - phase
                 - status
+                - user
               type: object
-            status:
-              type: boolean
-            user:
-              type: string
-          required:
-            - database
-            - instanceRef
-            - phase
-            - status
-            - user
           type: object
-      type: object
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: current db status
-    name: Phase
-    type: string
-  - JSONPath: .status.status
-    description: current db status
-    name: Status
-    type: boolean
-  - JSONPath: .spec.deletionProtected
-    description: If database is protected to not get deleted.
-    name: Protected
-    type: boolean
-  - JSONPath: .status.instanceRef.metadata.name
-    description: instance reference
-    name: DbInstance
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-    name: Age
-    type: date
+      additionalPrinterColumns:
+      - jsonPath: .status.phase
+        description: current db status
+        name: Phase
+        type: string
+      - jsonPath: .status.status
+        description: current db status
+        name: Status
+        type: boolean
+      - jsonPath: .spec.deletionProtected
+        description: If database is protected to not get deleted.
+        name: Protected
+        type: boolean
+      - jsonPath: .status.instanceRef.metadata.name
+        description: instance reference
+        name: DbInstance
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        description: |-
+          CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        name: Age
+        type: date
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dbinstances.kci.rocks
@@ -156,145 +159,148 @@ metadata:
 spec:
   group: kci.rocks
   scope: Cluster
-  version: v1alpha1
   names:
     kind: DbInstance
     listKind: DbInstanceList
     plural: dbinstances
     singular: dbinstance
     shortNames:
-    - dbin
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: DbInstance is the Schema for the dbinstances API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: DbInstanceSpec defines the desired state of DbInstance
-          type: object
-          required:
-            - adminSecretRef
-            - engine
-          oneOf:
-            - required:
-              - percona
-            - required:
-              - google
-            - required:
-              - generic
+      - dbin
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: DbInstance is the Schema for the dbinstances API
           properties:
-            engine:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
               type: string
-            adminSecretRef:
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
-              properties:
-                Namespace:
-                  type: string
-                Name:
-                  type: string
-            backup:
+            spec:
+              description: DbInstanceSpec defines the desired state of DbInstance
               type: object
-              properties:
-                bucket:
-                  type: string
               required:
-                - bucket
-            generic:
+                - adminSecretRef
+                - engine
+              oneOf:
+                - required:
+                  - percona
+                - required:
+                  - google
+                - required:
+                  - generic
               properties:
-                backupHost:
-                  description: BackupHost address will be used for dumping database for backup Usually secondary address for primary-secondary setup or cluster lb address If it's not defined, above Host will be used as backup host address.
+                engine:
                   type: string
-                host:
-                  type: string
-                port:
-                  type: integer
-                publicIp:
-                  type: string
-              required:
-                - host
-                - port
-              type: object
-            google:
-              description: GoogleInstance is used when instance type is Google Cloud SQL and describes necessary informations to use google API to create sql instances
-              properties:
-                configmapRef:
+                adminSecretRef:
                   type: object
-                instance:
-                  type: string
-              required:
-                - configmapRef
-                - instance
-              type: object
-            percona:
-              description: PerconaCluster is used when instance type is percona cluster
-              properties:
-                servers:
-                  type: array
-                  items:
-                    description: BackendServer defines backend database server
-                    required:
-                      - host
-                      - maxConn
-                      - port
-                    properties:
-                      host:
-                        type: string
-                      maxConn:
-                        minimum: 1
-                        type: integer
-                      port:
-                        type: integer
-                      readonly:
-                        type: boolean
-                    type: object
-                monitorUserSecretRef:
+                  properties:
+                    Namespace:
+                      type: string
+                    Name:
+                      type: string
+                backup:
                   type: object
-              required:
-                - monitorUserSecretRef
-                - servers
+                  properties:
+                    bucket:
+                      type: string
+                  required:
+                    - bucket
+                generic:
+                  properties:
+                    backupHost:
+                      description: BackupHost address will be used for dumping database for backup Usually secondary address for primary-secondary setup or cluster lb address If it's not defined, above Host will be used as backup host address.
+                      type: string
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    publicIp:
+                      type: string
+                  required:
+                    - host
+                    - port
+                  type: object
+                google:
+                  description: GoogleInstance is used when instance type is Google Cloud SQL and describes necessary informations to use google API to create sql instances
+                  properties:
+                    configmapRef:
+                      type: object
+                    instance:
+                      type: string
+                  required:
+                    - configmapRef
+                    - instance
+                  type: object
+                percona:
+                  description: PerconaCluster is used when instance type is percona cluster
+                  properties:
+                    servers:
+                      type: array
+                      items:
+                        description: BackendServer defines backend database server
+                        required:
+                          - host
+                          - maxConn
+                          - port
+                        properties:
+                          host:
+                            type: string
+                          maxConn:
+                            minimum: 1
+                            type: integer
+                          port:
+                            type: integer
+                          readonly:
+                            type: boolean
+                        type: object
+                    monitorUserSecretRef:
+                      type: object
+                  required:
+                    - monitorUserSecretRef
+                    - servers
+                  type: object
+                monitoring:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                  required:
+                    - enabled
+                sslConnection:
+                  description: DbInstanceSSLConnection defines weather connection from db-operator to instance has to be ssl or not
+                  properties:
+                    enabled:
+                      type: boolean
+                    skip-verify:
+                      description: SkipVerity use SSL connection, but don't check against a CA
+                      type: boolean
+                  required:
+                    - enabled
+                    - skip-verify
+                  type: object
+            status:
+              description: DbInstanceStatus defines the observed state of DbInstance
               type: object
-            monitoring:
-              type: object
-              properties:
-                enabled:
-                  type: boolean
-              required:
-                - enabled
-            sslConnection:
-              description: DbInstanceSSLConnection defines weather connection from db-operator to instance has to be ssl or not
-              properties:
-                enabled:
-                  type: boolean
-                skip-verify:
-                  description: SkipVerity use SSL connection, but don't check against a CA
-                  type: boolean
-              required:
-                - enabled
-                - skip-verify
-              type: object
-        status:
-          description: DbInstanceStatus defines the observed state of DbInstance
           type: object
-      type: object
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: current phase
-    name: Phase
-    type: string
-  - JSONPath: .status.status
-    description: health status
-    name: Status
-    type: boolean
+      additionalPrinterColumns:
+      - jsonPath: .status.phase
+        description: current phase
+        name: Phase
+        type: string
+      - jsonPath: .status.status
+        description: health status
+        name: Status
+        type: boolean

--- a/helm/db-operator/templates/rbac.yaml
+++ b/helm/db-operator/templates/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.rbac.create -}}
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "db-operator.name" . }}
   labels:
@@ -65,7 +65,7 @@ rules:
   - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "db-operator.name" . }}-sa
   labels:


### PR DESCRIPTION
With kubernetes v1.22, the apiVersion for the RBAC and CRDs for v1beta were removed, leaving just v1, along with some schema changes. The RBAC change is quite simple (`s/v1beta/v1/`) but the change for the CRDs brought some changes to the yaml as well, notably:
1. The `version:` singleton field for a shortcut for `versions` was removed, necessitating `versions:` and associated configuration
2. Fields in the schema don't appear allow for only adding `type: object` and leaving it at that without defining `properties:` entries; the nested/undefined values are dropped

I've therefore:
1. Updated the API version
2. Reacted in the CRD schema for `versions` to use the syntax for `v1`
3. Explicitly defined the `dbinstance` schema `status` fields that were depended on inside code
4. Extracted the `dbinstance` schema into a helm template and replicated it in the nested version in the `database` CRD

I think that longer term it's probably desirable in the database controller to either fetch the `dbinstance` object or to cache only a subset of the `dbinstance` fields instead of caching the whole k8s object inside the `database` object in the status field, but I elected to make the smallest change to support v1.22+.