### PR TITLE
METAL-3195/publish docker image on release

### DIFF
--- a/.github/workflows/image-publish.yaml
+++ b/.github/workflows/image-publish.yaml
@@ -1,9 +1,8 @@
 name: Publish Docker image
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published, edited]
 
 jobs:
   image-publish:


### PR DESCRIPTION
It doesn't not create action on tags creation.
We will go back to publishing image on release creation.