### PR TITLE
Fix URL to helm repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ DB Operator provides following features:
 ### To install DB Operator with helm:
 
 ```
-$ helm repo add db-operator https://kloeckner-i.github.io/db-operator/helm/
+$ helm repo add db-operator https://kloeckner-i.github.io/db-operator/
 $ helm install --name my-release db-operator/db-operator
 ```
 


### PR DESCRIPTION
Hey there

Your README has the wrong URL for the helm chart to be found; seems like something has changed and the /helm/ suffix is no longer needed.

```
$  helm repo add db-operator https://kloeckner-i.github.io/db-operator/helm/
Error: looks like "https://kloeckner-i.github.io/db-operator/helm/" is not a valid chart repository or cannot be reached: failed to fetch https://kloeckner-i.github.io/db-operator/helm/index.yaml : 404 Not Found

$ helm repo add db-operator https://kloeckner-i.github.io/db-operator/
db-operator" has been added to your repositories

$ helm install dbo db-operator/db-operator
NAME: dbo
LAST DEPLOYED: Sun Dec 19 18:29:16 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```