### PR TITLE
METAL-3261 add missing default helm values for service

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "0.15.1"
+appVersion: "1.2.0"
 description: A Database Operator
 name: db-operator
-version: 0.8.0
+version: 0.8.1

--- a/charts/db-operator/values.yaml
+++ b/charts/db-operator/values.yaml
@@ -110,3 +110,8 @@ serviceMonitor:
 #      targetLabel: nodename
 #      replacement: $1
 #      action: replace
+
+service:
+  annotations: {}
+  type: ClusterIP
+  port: 8080


### PR DESCRIPTION
* when service monitor is enabled, service resource will be created and it requires default values
* upgrade chart app version to latest