### PR TITLE
METAL-3262 re-release related to failed chart release pipeline

### DIFF
--- a/charts/db-instances/Chart.yaml
+++ b/charts/db-instances/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Database Instances for db operator
 name: db-instances
-version: 1.1.1
+version: 1.1.2


### PR DESCRIPTION
Release 1.1.1 was failed to build. retrigger chart release is not working, so make an re-release under new version.