### PR TITLE
METAL-3262 change k8s version definition, to also deploy to gke clusters

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-kubeVersion: ">= 1.19 <= 1.22"
+kubeVersion: ">= 1.19-prerelease <= 1.22-prerelease"
 appVersion: "1.3.0"
 description: A Database Operator
 name: db-operator
-version: 1.1.0
+version: 1.1.1


### PR DESCRIPTION
google version for k8s version is breaking the Semver rules. So to deploy this chart in an gke cluster, we need support pre-release version tags.