### PR TITLE
METAL-3262 fix: rbac issues in gke cluster

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -4,4 +4,4 @@ kubeVersion: ">= 1.19-prerelease <= 1.22-prerelease"
 appVersion: "1.3.0"
 description: A Database Operator
 name: db-operator
-version: 1.1.1
+version: 1.1.2

--- a/charts/db-operator/templates/rbac.yaml
+++ b/charts/db-operator/templates/rbac.yaml
@@ -56,8 +56,6 @@ rules:
   - get
   - list
   - watch
-  resourceNames:
-  - servicemonitors.monitoring.coreos.com
 - apiGroups:
   - monitoring.coreos.com
   resources:


### PR DESCRIPTION
Somehow, in gke it's sometimes report to not have the list permission, if the resource is limited to specific names.