### PR TITLE
METAL-3262 move cloud proxy monitoring from service to podmonitors

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 kubeVersion: ">= 1.19-prerelease <= 1.22-prerelease"
-appVersion: "1.3.0"
+appVersion: "1.4.0"
 description: A Database Operator
 name: db-operator
-version: 1.1.2
+version: 1.1.3

--- a/charts/db-operator/templates/rbac.yaml
+++ b/charts/db-operator/templates/rbac.yaml
@@ -60,6 +60,7 @@ rules:
   - monitoring.coreos.com
   resources:
   - servicemonitors
+  - podmonitors
   verbs:
   - create
   - update

--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -513,9 +513,9 @@ func (r *DatabaseReconciler) createProxy(ctx context.Context, dbcr *kciv1alpha1.
 		return err
 	}
 
-	if isMonitoringEnabled && inCrdList(crdList, "servicemonitors.monitoring.coreos.com") {
-		// create proxy PromServiceMonitor
-		promSvcMon, err := proxy.BuildServiceMonitor(proxyInterface)
+	if isMonitoringEnabled && inCrdList(crdList, "podmonitors.monitoring.coreos.com") {
+		// create proxy PromPodMonitor
+		promSvcMon, err := proxy.BuildPodMonitor(proxyInterface)
 		if err != nil {
 			return err
 		}

--- a/pkg/utils/proxy/create.go
+++ b/pkg/utils/proxy/create.go
@@ -56,11 +56,11 @@ func BuildConfigmap(proxy Proxy) (*v1.ConfigMap, error) {
 	return cm, nil
 }
 
-// BuildServiceMonitor builds kubernetes prometheus ServiceMonitor CR object used for monitoring
-func BuildServiceMonitor(proxy Proxy) (*promv1.ServiceMonitor, error) {
-	promSerMon, err := proxy.buildServiceMonitor()
+// BuildPodMonitor builds kubernetes prometheus PodMonitor CR object used for monitoring
+func BuildPodMonitor(proxy Proxy) (*promv1.PodMonitor, error) {
+	promSerMon, err := proxy.buildPodMonitor()
 	if err != nil {
-		logrus.Error("failed building promServiceMonitor configmap")
+		logrus.Error("failed building promPodMonitor configmap")
 		return nil, err
 	}
 

--- a/pkg/utils/proxy/types.go
+++ b/pkg/utils/proxy/types.go
@@ -26,6 +26,6 @@ import (
 type Proxy interface {
 	buildDeployment() (*v1apps.Deployment, error)
 	buildService() (*v1.Service, error)
-	buildServiceMonitor() (*promv1.ServiceMonitor, error)
+	buildPodMonitor() (*promv1.PodMonitor, error)
 	buildConfigMap() (*v1.ConfigMap, error)
 }

--- a/pkg/utils/thirdpartyapi/promv1.go
+++ b/pkg/utils/thirdpartyapi/promv1.go
@@ -8,8 +8,12 @@ import (
 )
 
 func AppendToScheme(scheme *runtime.Scheme) {
+
 	scheme.AddKnownTypes(crdv1.SchemeGroupVersion, &crdv1.CustomResourceDefinitionList{}, &crdv1.CustomResourceDefinition{})
 	metav1.AddToGroupVersion(scheme, crdv1.SchemeGroupVersion)
+
+	scheme.AddKnownTypes(promv1.SchemeGroupVersion, &promv1.PodMonitor{})
 	scheme.AddKnownTypes(promv1.SchemeGroupVersion, &promv1.ServiceMonitor{})
 	metav1.AddToGroupVersion(scheme, promv1.SchemeGroupVersion)
+
 }


### PR DESCRIPTION
Move the proxy monitoring for prometheus operator from service monitor to podmonitor. related each pod has different stats.