### PR TITLE
METAL-3549 do not mount volume when secret is undefined

### DIFF
--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -4,4 +4,4 @@ kubeVersion: ">= 1.19-prerelease <= 1.23-prerelease"
 appVersion: "1.6.1"
 description: A Database Operator
 name: db-operator
-version: 1.2.1
+version: 1.2.2

--- a/charts/db-operator/templates/operator.yaml
+++ b/charts/db-operator/templates/operator.yaml
@@ -70,9 +70,11 @@ spec:
           - mountPath: /run/secrets/gcloudsqladmin
             name: serviceaccount-cloudsql-admin
             readOnly: true
+          {{- if .Values.secrets.gsql.readonly }}
           - mountPath: /run/secrets/gcloudsqlclient
             name: serviceaccount-cloudsql-client
             readOnly: true
+          {{- end }}
           {{- end }}
           - mountPath: /run/config/
             name: config-volume
@@ -98,10 +100,12 @@ spec:
           secret:
             defaultMode: 420
             secretName: cloudsql-admin-serviceaccount
+      {{- if .Values.secrets.gsql.readonly }}
         - name: serviceaccount-cloudsql-client
           secret:
             defaultMode: 420
             secretName: cloudsql-readonly-serviceaccount
+      {{- end }}
       {{- end }}
         - name: config-volume
           configMap: 


### PR DESCRIPTION
bug fix - when readonly secret is undefined, volume shouldn't be mounted