### PR TITLE
METAL-3553 fix reconile requeue for db creation

### DIFF
--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -247,7 +247,7 @@ func (r *DatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		logrus.Infof("DB: namespace=%s, name=%s finish %s", dbcr.Namespace, dbcr.Name, phase)
-		return reconcileResult, nil // success phase
+		return reconcile.Result{Requeue: true}, nil // success phase, but not done ... requeue for next step
 	}
 
 	// status true do nothing and don't requeue


### PR DESCRIPTION
After a phase change, the request was requeued with the r.interval (helm chart 60sec). This resulting in process a db-creation in around 5-6min. Now the requeue is happen instant and a db creation takes only seconds.