### PR TITLE
feat: postgres exporter username key, password key and uri can be overwritten

### DIFF
--- a/charts/db-instances/Chart.yaml
+++ b/charts/db-instances/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Database Instances for db operator
 name: db-instances
-version: 1.2.0
+version: 1.3.0

--- a/charts/db-instances/templates/postgres_exporter.yaml
+++ b/charts/db-instances/templates/postgres_exporter.yaml
@@ -32,11 +32,11 @@ spec:
       containers:
       - env:
         - name: DATA_SOURCE_URI
-          value: dbinstance-{{ $name }}-svc:5432/postgres?sslmode=disable
+          value: {{ $value.monitoring.uri | default (printf "dbinstance-%s-svc:5432/postgres?sslmode=disable" $name) }}
         - name: DATA_SOURCE_PASS_FILE
-          value: /run/secrets/db-secrets/password
+          value: /run/secrets/db-secrets/{{ $value.monitoring.passwordKey | default "password" }}
         - name: DATA_SOURCE_USER_FILE
-          value: /run/secrets/db-secrets/user
+          value: /run/secrets/db-secrets/{{ $value.monitoring.usernameKey | default "user" }}
         - name: PG_EXPORTER_WEB_LISTEN_ADDRESS
           value: :60000
         - name: PG_EXPORTER_EXTEND_QUERY_PATH


### PR DESCRIPTION
This solves #144 and makes monitoring feature for example usable with the Zalando Postgres Operator.

It introduces no backwards incompatible changes, as the defaults are the old values.

