### PR TITLE
feature-update-supported-k8s-version

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -97,7 +97,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        k8s_version: ['v1.21.6', 'v1.22.3', 'v1.23.1']
+        k8s_version: ['v1.21.6', 'v1.22.3', 'v1.23.1', 'v1.24.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 ## All supported k8s versions are in the test: https://github.com/kloeckner-i/db-operator/blob/master/.github/workflows/build-and-test.yaml
-kubeVersion: ">= 1.21"
+kubeVersion: ">= 1.21-prerelease"
 appVersion: "1.6.5"
 description: A Database Operator
 name: db-operator

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 type: application
-kubeVersion: ">= 1.21" ## see all supported versions in the test: https://github.com/kloeckner-i/db-operator/blob/master/.github/workflows/build-and-test.yaml
+## All supported k8s versions are in the test: https://github.com/kloeckner-i/db-operator/blob/master/.github/workflows/build-and-test.yaml
+kubeVersion: ">= 1.21"
 appVersion: "1.6.5"
 description: A Database Operator
 name: db-operator

--- a/charts/db-operator/Chart.yaml
+++ b/charts/db-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
-kubeVersion: ">= 1.19-prerelease <= 1.23-prerelease"
+kubeVersion: ">= 1.21" ## see all supported versions in the test: https://github.com/kloeckner-i/db-operator/blob/master/.github/workflows/build-and-test.yaml
 appVersion: "1.6.5"
 description: A Database Operator
 name: db-operator
-version: 1.2.6
+version: 1.2.7


### PR DESCRIPTION
We are not able to install db-operator helm chart into kubernetes v1.24 because of upper bound constraint:
[kubeVersion: ">= 1.19-prerelease <= 1.23-prerelease"](https://github.com/kloeckner-i/db-operator/blob/55bbcb2cd7318ea893a07601c067f96db93c623f/charts/db-operator/Chart.yaml#L3) .

What do you think about removing this constraint and inform customers about `matrix.k8s_version`([build-and-test.yaml](https://github.com/vladimir22/db-operator/blob/21b0c0fe3cb5964d332f540fc89671830d406ebc/.github/workflows/build-and-test.yaml#L100)) section with all supported k8s versions instead?

Thanks.


